### PR TITLE
Fix warnings, bump elixir version to 1.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add gravity to your list of dependencies in `mix.exs`:
 
 ```
         def deps do
-          [{:gravity, "~> 1.0.0"}]
+          [{:gravity, "~> 1.0.1"}]
         end
 ```
 

--- a/lib/gravity/hash.ex
+++ b/lib/gravity/hash.ex
@@ -13,7 +13,7 @@ defmodule Gravity.Hash do
   @spec build(String.t) :: String.t
   def build(email) do
     email
-    |> String.strip
+    |> String.trim
     |> String.downcase
     |> Crypto.md5
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,13 +3,13 @@ defmodule Gravity.Mixfile do
 
   def project do
     [app: :gravity,
-     version: "1.0.0",
-     elixir: "~> 1.2",
+     version: "1.0.1",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
This PR fixes warnings related to mix, and the deprecation of `String.strip/1` in 1.3.
I was unsure as to which version number I should bump in order to comply with semver. The change is technically non-breaking, you just won't be able to upgrade if using 1.2 or lower, so I bumped the patch version.